### PR TITLE
fix: useEditedComment state stuck on pending/failed when edit succeeds

### DIFF
--- a/src/hooks/accounts/accounts.ts
+++ b/src/hooks/accounts/accounts.ts
@@ -453,7 +453,7 @@ export function useEditedComment(options?: UseEditedCommentOptions): UseEditedCo
     }
 
     // don't include these props as they are not edit props, they are publication props
-    const nonEditPropertyNames = new Set(['author, signer', 'commentCid', 'subplebbitAddress', 'timestamp'])
+    const nonEditPropertyNames = new Set(['author', 'signer', 'commentCid', 'subplebbitAddress', 'timestamp'])
 
     // iterate over commentEdits and consolidate them into 1 propertyNameEdits object
     const propertyNameEdits: any = {}


### PR DESCRIPTION
Fix typo in nonEditPropertyNames Set where 'author, signer' was treated as a single string instead of separate 'author' and 'signer' strings. This caused author/signer properties to contaminate edit success comparison, making successful edits appear as failed.