### PR TITLE
fix: useEditedComment state transitions with callback property exclusion

### DIFF
--- a/src/hooks/accounts/accounts.ts
+++ b/src/hooks/accounts/accounts.ts
@@ -452,8 +452,18 @@ export function useEditedComment(options?: UseEditedCommentOptions): UseEditedCo
       return editedResult
     }
 
-    // don't include these props as they are not edit props, they are publication props
-    const nonEditPropertyNames = new Set(['author', 'signer', 'commentCid', 'subplebbitAddress', 'timestamp'])
+    // don't include these props as they are not edit props, they are publication props or callback functions
+    const nonEditPropertyNames = new Set([
+      'author',
+      'signer',
+      'commentCid',
+      'subplebbitAddress',
+      'timestamp',
+      'onChallenge',
+      'onChallengeVerification',
+      'onError',
+      'onPublishingStateChange',
+    ])
 
     // iterate over commentEdits and consolidate them into 1 propertyNameEdits object
     const propertyNameEdits: any = {}

--- a/src/hooks/accounts/accounts.ts
+++ b/src/hooks/accounts/accounts.ts
@@ -453,7 +453,7 @@ export function useEditedComment(options?: UseEditedCommentOptions): UseEditedCo
     }
 
     // don't include these props as they are not edit props, they are publication props
-    const nonEditPropertyNames = new Set(['author, signer', 'commentCid', 'subplebbitAddress', 'timestamp'])
+    const nonEditPropertyNames = new Set(['author', 'signer', 'commentCid', 'subplebbitAddress', 'timestamp'])
 
     // iterate over commentEdits and consolidate them into 1 propertyNameEdits object
     const propertyNameEdits: any = {}


### PR DESCRIPTION
Expand nonEditPropertyNames exclusion set to include callback function properties (onChallenge, onChallengeVerification, onError, onPublishingStateChange) that were contaminating the isEqual comparison in useEditedComment.